### PR TITLE
Step 3 : API 구현

### DIFF
--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -25,7 +25,7 @@ struct ItemController: RouteCollection {
                 lists.append(ItemList(state: key, list: value))
             }
             let body = try jsonEncoder.encode(lists)
-            return Response(status: .created,
+            return Response(status: .ok,
                             headers: header,
                             body: .init(data: body))
         }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -28,14 +28,14 @@ struct ItemController: RouteCollection {
         try checkContentType(req.headers.contentType)
         try Item.validate(content: req)
         let item = try req.content.decode(Item.self)
-        return item.save(on: req.db).map { item }
+        return Item.save(on: req.db).map { item }
     }
     
 //    private func update(req: Request) throws -> EventLoopFuture<Item> {
 //        try checkContentType(req.headers.contentType)
 //        try Item.validate(content: req)
 //        let item = try req.content.decode(Item.self)
-//        return item.update(on: req.db).map { item }
+//        return Item.update(on: req.db).map { item }
 //    }
 //
     private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -9,7 +9,7 @@ struct ItemController: RouteCollection {
         let item = routes.grouped("item")
         item.post(use: create)
 //        item.patch(":id", use: update)
-//        item.delete(":id", use: delete)
+        item.delete(":id", use: delete)
     }
     
     private func readAll(req: Request) throws -> EventLoopFuture<[ItemList]> {
@@ -38,13 +38,14 @@ struct ItemController: RouteCollection {
 //        return item.update(on: req.db).map { item }
 //    }
 //
-//    private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
-//        try checkContentType(req.headers.contentType)
-//        return Item.find(req.parameters.get("itemID"), on: req.db)
-//            .unwrap(or: Abort(.notFound))
-//            .flatMap { $0.delete(on: req.db) }
-//            .transform(to: .ok)
-//    }
+    private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        try checkContentType(req.headers.contentType)
+        let id = try checkID(req)
+        return Item.find(id, on: req.db)
+            .unwrap(or: Abort(.notFound))
+            .flatMap { $0.delete(on: req.db) }
+            .transform(to: .ok)
+    }
     
     private func checkContentType(_ contentType: HTTPMediaType?) throws {
         guard let contentType = contentType, contentType == .json else {

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -104,7 +104,7 @@ struct ItemController: RouteCollection {
     
     private func checkID(_ req: Request) throws -> Int {
         guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
-            throw ThingError.invalidID
+            throw ItemError.invalidID
         }
         return id
     }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -40,11 +40,7 @@ struct ItemController: RouteCollection {
 //
     private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
         try checkContentType(req.headers.contentType)
-        
-        guard let id = UUID(uuidString: req.parameters.get("id")!) else {
-                    throw Abort(.badRequest)
-                }
-        
+        let id = try checkID(req)
         return Item.find(id, on: req.db)
             .unwrap(or: Abort(.notFound))
             .flatMap { $0.delete(on: req.db) }
@@ -57,10 +53,10 @@ struct ItemController: RouteCollection {
         }
     }
     
-//    private func checkID(_ req: Request) throws -> Int {
-//        guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
-//            throw Abort(.notFound)
-//        }
-//        return id
-//    }
+    private func checkID(_ req: Request) throws -> Int {
+        guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
+            throw Abort(.notFound)
+        }
+        return id
+    }
 }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -40,7 +40,11 @@ struct ItemController: RouteCollection {
 //
     private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
         try checkContentType(req.headers.contentType)
-        let id = try checkID(req)
+        
+        guard let id = UUID(uuidString: req.parameters.get("id")!) else {
+                    throw Abort(.badRequest)
+                }
+        
         return Item.find(id, on: req.db)
             .unwrap(or: Abort(.notFound))
             .flatMap { $0.delete(on: req.db) }
@@ -53,10 +57,10 @@ struct ItemController: RouteCollection {
         }
     }
     
-    private func checkID(_ req: Request) throws -> Int {
-        guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
-            throw Abort(.notFound)
-        }
-        return id
-    }
+//    private func checkID(_ req: Request) throws -> Int {
+//        guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
+//            throw Abort(.notFound)
+//        }
+//        return id
+//    }
 }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -16,6 +16,7 @@ struct ItemController: RouteCollection {
     }
 
     func create(req: Request) throws -> EventLoopFuture<Item> {
+        try Item.validate(content: req)
         let item = try req.content.decode(Item.self)
         return item.save(on: req.db).map { item }
     }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -4,14 +4,14 @@ import Vapor
 struct ItemController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let items = routes.grouped("items")
-        items.get(use: index)
+        items.get(use: readAll)
         items.post(use: create)
         items.group(":itemID") { item in
             items.delete(use: delete)
         }
     }
 
-    func index(req: Request) throws -> EventLoopFuture<[Item]> {
+    func readAll(req: Request) throws -> EventLoopFuture<[Item]> {
         return Item.query(on: req.db).all()
     }
 

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -104,7 +104,7 @@ struct ItemController: RouteCollection {
     
     private func checkID(_ req: Request) throws -> Int {
         guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
-            throw Abort(.notFound)
+            throw ThingError.invalidID
         }
         return id
     }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -5,23 +5,41 @@ struct ItemController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let items = routes.grouped("items")
         items.get(use: readAll)
-        items.post(use: create)
-        items.group(":itemID") { item in
-            items.delete(use: delete)
+        
+        let item = routes.grouped("item")
+        item.post(use: create)
+        item.patch(":id", use: update)
+        item.delete(":id", use: delete)
+    }
+    
+    private func readAll(req: Request) throws -> EventLoopFuture<[ItemList]> {
+        try checkContentType(req.headers.contentType)
+        return Item.query(on: req.db).all().map { things -> [ItemList] in
+            let group = Dictionary(grouping: things, by: { $0.state })
+            var lists: [ItemList] = []
+            for (key, value) in group {
+                lists.append(ItemList(state: key, list: value))
+            }
+            return lists
         }
     }
-
-    func readAll(req: Request) throws -> EventLoopFuture<[Item]> {
-        return Item.query(on: req.db).all()
-    }
-
-    func create(req: Request) throws -> EventLoopFuture<Item> {
+    
+    private func create(req: Request) throws -> EventLoopFuture<Item> {
+        try checkContentType(req.headers.contentType)
         try Item.validate(content: req)
         let item = try req.content.decode(Item.self)
         return item.save(on: req.db).map { item }
     }
-
-    func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+    
+    private func update(req: Request) throws -> EventLoopFuture<Item> {
+        try checkContentType(req.headers.contentType)
+        try Item.validate(content: req)
+        let item = try req.content.decode(Item.self)
+        return item.update(on: req.db).map { item }
+    }
+    
+    private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        try checkContentType(req.headers.contentType)
         return Item.find(req.parameters.get("itemID"), on: req.db)
             .unwrap(or: Abort(.notFound))
             .flatMap { $0.delete(on: req.db) }

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -15,7 +15,6 @@ struct ItemController: RouteCollection {
         item.delete(":id", use: delete)
     }
     
-    // Todo: header 포함해서 보내기, last_modifed double로 내려주기
     private func readAll(req: Request) throws -> EventLoopFuture<Response> {
         try checkContentType(req.headers.contentType)
         return Item.query(on: req.db).all().flatMapThrowing { things in
@@ -49,7 +48,6 @@ struct ItemController: RouteCollection {
         }
     }
     
-    // update 잘되는건지 모르겠음
     private func update(req: Request) throws -> EventLoopFuture<Response> {
         try checkContentType(req.headers.contentType)
         let id = try checkID(req)

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -15,6 +15,7 @@ struct ItemController: RouteCollection {
         item.delete(":id", use: delete)
     }
     
+    // Todo: header 포함해서 보내기, last_modifed double로 내려주기
     private func readAll(req: Request) throws -> EventLoopFuture<[ItemList]> {
         try checkContentType(req.headers.contentType)
         return Item.query(on: req.db).all().map { things -> [ItemList] in
@@ -45,6 +46,7 @@ struct ItemController: RouteCollection {
         }
     }
     
+    // update 잘되는건지 모르겠음
     private func update(req: Request) throws -> EventLoopFuture<Response> {
         try checkContentType(req.headers.contentType)
         let id = try checkID(req)

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -8,8 +8,8 @@ struct ItemController: RouteCollection {
         
         let item = routes.grouped("item")
         item.post(use: create)
-        item.patch(":id", use: update)
-        item.delete(":id", use: delete)
+//        item.patch(":id", use: update)
+//        item.delete(":id", use: delete)
     }
     
     private func readAll(req: Request) throws -> EventLoopFuture<[ItemList]> {
@@ -31,20 +31,20 @@ struct ItemController: RouteCollection {
         return item.save(on: req.db).map { item }
     }
     
-    private func update(req: Request) throws -> EventLoopFuture<Item> {
-        try checkContentType(req.headers.contentType)
-        try Item.validate(content: req)
-        let item = try req.content.decode(Item.self)
-        return item.update(on: req.db).map { item }
-    }
-    
-    private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
-        try checkContentType(req.headers.contentType)
-        return Item.find(req.parameters.get("itemID"), on: req.db)
-            .unwrap(or: Abort(.notFound))
-            .flatMap { $0.delete(on: req.db) }
-            .transform(to: .ok)
-    }
+//    private func update(req: Request) throws -> EventLoopFuture<Item> {
+//        try checkContentType(req.headers.contentType)
+//        try Item.validate(content: req)
+//        let item = try req.content.decode(Item.self)
+//        return item.update(on: req.db).map { item }
+//    }
+//
+//    private func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+//        try checkContentType(req.headers.contentType)
+//        return Item.find(req.parameters.get("itemID"), on: req.db)
+//            .unwrap(or: Abort(.notFound))
+//            .flatMap { $0.delete(on: req.db) }
+//            .transform(to: .ok)
+//    }
     
     private func checkContentType(_ contentType: HTTPMediaType?) throws {
         guard let contentType = contentType, contentType == .json else {

--- a/Sources/App/Controllers/ItemController.swift
+++ b/Sources/App/Controllers/ItemController.swift
@@ -45,4 +45,17 @@ struct ItemController: RouteCollection {
             .flatMap { $0.delete(on: req.db) }
             .transform(to: .ok)
     }
+    
+    private func checkContentType(_ contentType: HTTPMediaType?) throws {
+        guard let contentType = contentType, contentType == .json else {
+            throw Abort(.unsupportedMediaType)
+        }
+    }
+    
+    private func checkID(_ req: Request) throws -> Int {
+        guard let parameterID = req.parameters.get("id"), let id = Int(parameterID) else {
+            throw Abort(.notFound)
+        }
+        return id
+    }
 }

--- a/Sources/App/Error/ItemError.swift
+++ b/Sources/App/Error/ItemError.swift
@@ -13,7 +13,7 @@ enum ItemError: AbortError {
     var reason: String {
         switch self {
         case .invalidID:
-            return "ID must be integer type."
+            return "id is not a(n) Integer"
         }
     }
     

--- a/Sources/App/Error/ItemError.swift
+++ b/Sources/App/Error/ItemError.swift
@@ -14,11 +14,13 @@ enum ItemError: AbortError {
         switch self {
         case .invalidID:
             return "ID must be integer type."
+        }
     }
     
     var status: HTTPStatus {
         switch self {
         case .invalidID:
             return .badRequest
+        }
     }
 }

--- a/Sources/App/Error/ItemError.swift
+++ b/Sources/App/Error/ItemError.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by 리나 on 2021/04/06.
+//
+
+import Vapor
+
+enum ItemError: AbortError {
+    case invalidID
+    
+    var reason: String {
+        switch self {
+        case .invalidID:
+            return "ID must be integer type."
+    }
+    
+    var status: HTTPStatus {
+        switch self {
+        case .invalidID:
+            return .badRequest
+    }
+}

--- a/Sources/App/Migrations/CreateItem.swift
+++ b/Sources/App/Migrations/CreateItem.swift
@@ -11,7 +11,7 @@ struct CreateItem: Migration {
         
         return database.enum("state").read().flatMap { state in
             database.schema(Item.schema)
-                .id()
+                .field("id", .custom("serial"))
                 .field("title", .string, .required)
                 .field("body", .string, .required)
                 .field("state", state, .required)

--- a/Sources/App/Migrations/CreateItem.swift
+++ b/Sources/App/Migrations/CreateItem.swift
@@ -10,7 +10,7 @@ struct CreateItem: Migration {
             .create()
         
         return database.enum("state").read().flatMap { state in
-            database.schema("items")
+            database.schema(Item.schema)
                 .id()
                 .field("title", .string, .required)
                 .field("body", .string, .required)
@@ -22,6 +22,6 @@ struct CreateItem: Migration {
     }
     
     func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("items").delete()
+        return database.schema(Item.schema).delete()
     }
 }

--- a/Sources/App/Migrations/CreateItem.swift
+++ b/Sources/App/Migrations/CreateItem.swift
@@ -11,7 +11,7 @@ struct CreateItem: Migration {
         
         return database.enum("state").read().flatMap { state in
             database.schema(Item.schema)
-                .field("id", .custom("serial"))
+                .id()
                 .field("title", .string, .required)
                 .field("body", .string, .required)
                 .field("state", state, .required)

--- a/Sources/App/Models/EditedItem.swift
+++ b/Sources/App/Models/EditedItem.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//  
+//
+//  Created by 리나 on 2021/04/06.
+//
+
+import Vapor
+
+struct EditedItem: Content {
+    let title: String?
+    let body: String?
+    let state: State?
+    let deadline: Double?
+    
+    enum CodingKeys: String, CodingKey {
+        case title, body, state, deadline
+    }
+}
+
+extension EditedItem: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: .count(...500), required: false)
+        validations.add("body", as: String.self, is: .count(...1000), required: false)
+        validations.add("state", as: String.self, is: .in(State.allCases.map { $0.rawValue }), required: false)
+        validations.add("deadline", as: Double?.self, required: false)
+    }
+}

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -5,7 +5,7 @@ final class Item: Model, Content {
     static let schema = "items"
     
     @ID(key: .id)
-    var id: UUID?
+    let id: UUID?
 
     @Field(key: "title")
     var title: String

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -24,7 +24,7 @@ final class Item: Model, Content {
     
     init() { }
 
-    init(id: Int? = nil,
+    init(id: UUID? = nil,
          title: String,
          body: String,
          state: State,

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -47,7 +47,7 @@ extension Item: Validatable {
     static func validations(_ validations: inout Validations) {
         validations.add("title", as: String.self, is: .count(...500))
         validations.add("body", as: String.self, is: .count(...1000))
-        validations.add("status", as: String.self, is: .in("todo", "doing", "done"))
+        validations.add("state", as: String.self, is: .in("todo", "doing", "done"))
         validations.add("deadline", as: Double?.self, required: false)
     }
 }

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -19,7 +19,7 @@ final class Item: Model, Content {
     @OptionalField(key: "deadline")
     var deadline: Double?
     
-    @Timestamp(key: "last_modified", on: .update)
+    @Timestamp(key: "last_modified", on: .update, format: .unixl)
     var last_modified: Date?
     
     init() { }

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -38,12 +38,3 @@ final class Item: Model, Content {
         self.last_modified = last_modified
     }
 }
-
-extension Item: Validatable {
-    static func validations(_ validations: inout Validations) {
-        validations.add("title", as: String.self, is: .count(...500))
-        validations.add("body", as: String.self, is: .count(...1000))
-        validations.add("state", as: String.self, is: .in(State.allCases.map { $0.rawValue }))
-        validations.add("deadline", as: Double?.self, required: false)
-    }
-}

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -4,8 +4,8 @@ import Vapor
 final class Item: Model, Content {
     static let schema = "items"
     
-    @ID(key: .id)
-    var id: UUID?
+    @ID(custom: "id", generatedBy: .database)
+    var id: Int?
 
     @Field(key: "title")
     var title: String
@@ -24,7 +24,7 @@ final class Item: Model, Content {
     
     init() { }
 
-    init(id: UUID? = nil,
+    init(id: Int? = nil,
          title: String,
          body: String,
          state: State,

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -19,7 +19,7 @@ final class Item: Model, Content {
     @OptionalField(key: "deadline")
     var deadline: Double?
     
-    @Timestamp(key: "last_modified", on: .update, format: .unix)
+    @Timestamp(key: "last_modified", on: .update)
     var last_modified: Date?
     
     init() { }

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -4,8 +4,8 @@ import Vapor
 final class Item: Model, Content {
     static let schema = "items"
     
-    @ID(key: .id)
-    var id: UUID?
+    @ID(custom: "id", generatedBy: .database)
+    var id: Int?
 
     @Field(key: "title")
     var title: String

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -19,7 +19,7 @@ final class Item: Model, Content {
     @OptionalField(key: "deadline")
     var deadline: Double?
     
-    @Timestamp(key: "last_modified", on: .update, format: .unixl)
+    @Timestamp(key: "last_modified", on: .update, format: .unix)
     var last_modified: Date?
     
     init() { }

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -4,8 +4,8 @@ import Vapor
 final class Item: Model, Content {
     static let schema = "items"
     
-    @ID(custom: "id", generatedBy: .database)
-    var id: Int?
+    @ID(key: .id)
+    var id: UUID?
 
     @Field(key: "title")
     var title: String

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -42,3 +42,12 @@ final class Item: Model, Content {
         self.last_modified = last_modified
     }
 }
+
+extension Item: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: .count(...500))
+        validations.add("body", as: String.self, is: .count(...1000))
+        validations.add("status", as: String.self, is: .in("todo", "doing", "done"))
+        validations.add("deadline", as: Double?.self, required: false)
+    }
+}

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -4,8 +4,8 @@ import Vapor
 final class Item: Model, Content {
     static let schema = "items"
     
-    @ID(custom: "id", generatedBy: .database)
-    var id: Int?
+    @ID(key: .id)
+    var id: UUID?
 
     @Field(key: "title")
     var title: String
@@ -24,7 +24,7 @@ final class Item: Model, Content {
     
     init() { }
 
-    init(id: Int? = nil,
+    init(id: UUID? = nil,
          title: String,
          body: String,
          state: State,

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -24,7 +24,7 @@ final class Item: Model, Content {
     
     init() { }
 
-    init(id: UUID? = nil,
+    init(id: Int? = nil,
          title: String,
          body: String,
          state: State,

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -5,7 +5,7 @@ final class Item: Model, Content {
     static let schema = "items"
     
     @ID(key: .id)
-    let id: UUID?
+    var id: UUID?
 
     @Field(key: "title")
     var title: String

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -4,9 +4,9 @@ import Vapor
 final class Item: Model, Content {
     static let schema = "items"
     
-    @ID(key: .id)
-    var id: UUID?
-    
+    @ID(custom: "id", generatedBy: .database)
+    var id: Int?
+
     @Field(key: "title")
     var title: String
     

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -6,7 +6,7 @@ final class Item: Model, Content {
     
     @ID(key: .id)
     var id: UUID?
-
+    
     @Field(key: "title")
     var title: String
     
@@ -22,7 +22,7 @@ final class Item: Model, Content {
     @Timestamp(key: "last_modified", on: .update)
     var last_modified: Date?
     
-    enum State: String, Codable {
+    enum State: String, Codable, CaseIterable {
         case todo, doing, done
     }
     
@@ -47,7 +47,7 @@ extension Item: Validatable {
     static func validations(_ validations: inout Validations) {
         validations.add("title", as: String.self, is: .count(...500))
         validations.add("body", as: String.self, is: .count(...1000))
-        validations.add("state", as: String.self, is: .in("todo", "doing", "done"))
+        validations.add("state", as: String.self, is: .in(State.allCases.map { $0.rawValue }))
         validations.add("deadline", as: Double?.self, required: false)
     }
 }

--- a/Sources/App/Models/Item.swift
+++ b/Sources/App/Models/Item.swift
@@ -22,10 +22,6 @@ final class Item: Model, Content {
     @Timestamp(key: "last_modified", on: .update)
     var last_modified: Date?
     
-    enum State: String, Codable, CaseIterable {
-        case todo, doing, done
-    }
-    
     init() { }
 
     init(id: UUID? = nil,

--- a/Sources/App/Models/ItemList.swift
+++ b/Sources/App/Models/ItemList.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+struct ThingList: Content {
+     var state: State
+     var list: [Item]
+ }

--- a/Sources/App/Models/ItemList.swift
+++ b/Sources/App/Models/ItemList.swift
@@ -8,6 +8,6 @@
 import Vapor
 
 struct ItemList: Content {
-     var state: State
-     var list: [Item]
+     let state: State
+     let list: [Item]
  }

--- a/Sources/App/Models/ItemList.swift
+++ b/Sources/App/Models/ItemList.swift
@@ -5,9 +5,9 @@
 //  Created by 리나 on 2021/04/05.
 //
 
-import Foundation
+import Vapor
 
-struct ThingList: Content {
+struct ItemList: Content {
      var state: State
      var list: [Item]
  }

--- a/Sources/App/Models/ItemList.swift
+++ b/Sources/App/Models/ItemList.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by 리나 on 2021/04/05.
+//
+
+import Foundation

--- a/Sources/App/Models/NewItem.swift
+++ b/Sources/App/Models/NewItem.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//  
+//
+//  Created by 리나 on 2021/04/06.
+//
+
+import Vapor
+
+struct NewItem: Content {
+    let title: String
+    let body: String
+    let state: State
+    let deadline: Double?
+    
+    enum CodingKeys: String, CodingKey {
+        case title, body, state, deadline
+    }
+}
+
+extension NewItem: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: .count(...500))
+        validations.add("body", as: String.self, is: .count(...1000))
+        validations.add("state", as: String.self, is: .in(State.allCases.map { $0.rawValue }))
+        validations.add("deadline", as: Double?.self, required: false)
+    }
+}

--- a/Sources/App/Models/State.swift
+++ b/Sources/App/Models/State.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by 리나 on 2021/04/05.
+//
+
+import Foundation
+
+enum State: String, Codable, CaseIterable {
+    case todo, doing, done
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -23,3 +23,4 @@ public func configure(_ app: Application) throws {
     
     try routes(app)
 }
+

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -20,6 +20,6 @@ public func configure(_ app: Application) throws {
     }
     
     app.migrations.add(CreateItem())
-    
+    try app.autoMigrate().wait()
     try routes(app)
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -13,9 +13,9 @@ public func configure(_ app: Application) throws {
         app.databases.use(.postgres(
             hostname: Environment.get("DATABASE_HOST") ?? "localhost",
             port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? PostgresConfiguration.ianaPortNumber,
-            username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
-            password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
-            database: Environment.get("DATABASE_NAME") ?? "vapor_database"
+            username: Environment.get("DATABASE_USERNAME") ?? "postgres",
+            password: Environment.get("DATABASE_PASSWORD") ?? "1234",
+            database: Environment.get("DATABASE_NAME") ?? "postgres"
         ), as: .psql)
     }
     
@@ -23,4 +23,3 @@ public func configure(_ app: Application) throws {
     try app.autoMigrate().wait()
     try routes(app)
 }
-

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -2,13 +2,5 @@ import Fluent
 import Vapor
 
 func routes(_ app: Application) throws {
-    app.get { req in
-        return "It works!"
-    }
-
-    app.get("hello") { req -> String in
-        return "Hello, world!"
-    }
-
     try app.register(collection: ItemController())
 }

--- a/mock/mockdata-error-sample.dataset/error_sample.json
+++ b/mock/mockdata-error-sample.dataset/error_sample.json
@@ -1,3 +1,4 @@
 {
-    "error": "mock data 오류입니다."
+     "error": true,
+     "reason": "Unsupported Media Type"
 }


### PR DESCRIPTION
Hello ma innie😘,

Thank you for visiting my step pull request🙃

제가 일단 step3를 얼추 다 한것같은데,
이니 하고나면 천천히 보아주세요.
(수요일은 쉬고 목요일에 얘기해요. 왜냐면 전 지금부터 42seoul minishell 하러가야하거든요.. 울컥..)

## step3 구현

- [x] **인코딩 및 디코딩에 필요한 타입을 정의합니다**
> 처음에는 어떤 의미인지 몰랐는데, 새로운 item이나 item을 업데이트 할 때 필요해서 생성했습니다!

- [x] **클라이언트의 요청에 대한 검증을 구현합니다**
> 이 부분이 미흡하다고 생각이 들긴 하지만, 무엇을 더 해야하지는 모르겠어요.  
`Request parameter가 유효한 값인지` -> id가 int인지 확인하는 것 외에는 validation으로 했습니답. 근데 이게 맞는지 모르겠네용?
`Request body의 데이터가 유효한지` -> 위에 것과 무엇이 다른지 정확하게 인지하지 못했습니다😖
`Request header의 Content-Type이 지정된 타입인지` -> application/json으로 우선 설정해뒀습니다.

- [x] **데이터베이스에서 데이터를 생성/조회/수정/삭제하고 응답합니다**
> 전부 다 작동이 됩니다. 다만 조회에서 last_modified가 `String`으로 내려가고 있던데; 이건 수정해야 할 것 같아요.
그리고 조회에서 header를 안내려주는 것도 수정하려고 합니다!
또, 수정 부분이 잘 되는건지 모르겠습니다. null을 던졌을때, null일 수 없다고 하는게 뭔가 이상해요;

- [x] **오류 타입을 정의하여 상황에 맞는 HTTP 상태 코드와 오류 메시지를 전달합니다**
> 오류 타입을 별도로 정의하였는데, 할만한 오류가 `id가 int인지 확인하는 것` 뿐이라... 그것만 해뒀습니당


## step2 리뷰 관련

델마가 달아준 리뷰가ㅎㅎㅎㅎ step3를 제가 진행하면서 수정했던 부분들이라 저는 이미 모두 변경되어 있었는데요.
이니는 어떻게 되었는지 말씀해주세용

그런데 단 한개 변경하지 않은게 있어요!
```
어떤 Item인지 네이밍이 조금 더 명확해지면 좋겠습니다. 예컨대 TaskItem 같은..?
```
👆요거는 이니랑 이야기해보고 싶었어요.

저는 사실 Item 그대로도 나쁘지 않을것 같다는 생각이 들었는데, 좋은 네이밍 아이디어 있나요 이니😍

++ delete 인증 관련해서도 생각해볼게용.


## 리나 할 일 정리
- [x] readAll에서 last_modified `Double` 타입으로!
- [x] readAll에 `header`같이 response하기!
- [ ] delete 인증 구현
- [x] API에 error 기술


이니 안되는 것 있으면 언제든 같ㅇㅣ 해여ㅕㅕㅕㅕ 이야아아아아ㅜ아아 화이티이이운아일!