### PR TITLE
Step 4 : 테스트 수행

### DIFF
--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -10,28 +10,28 @@ final class AppTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
-
+        
         try app.test(.GET, "items", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
         })
     }
-
+    
     func testGetFailureCase() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
-
+        
         let invalidURI = "item"
         try app.test(.GET, invalidURI, afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
         })
     }
-
+    
     func testPostSuccessCase() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
-
+       
         let item = Item(title: "title", body: "body", state: .todo, deadline: nil)
         let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
         
@@ -39,12 +39,12 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .created)
         }
     }
-
+    
     func testPostFailureCase_longTitle() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
-
+        
         let longTitle = "title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. "
         let item = Item(title: longTitle, body: "body", state: .todo, deadline: nil)
         let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
@@ -58,7 +58,7 @@ final class AppTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
-
+        
         let longBody = "Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다."
         let item = Item(title: "title", body: longBody, state: .todo, deadline: nil)
         let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
@@ -67,17 +67,27 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .badRequest)
         }
     }
-
+    
     func testPatchFailureCase() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
-
+        
         let item = Item(title: "New title", body: "New body", state: .doing, deadline: nil)
         let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
-
+        
         try app.test(.PATCH, "item", headers: header, body: body) { res in
             XCTAssertEqual(res.status, .notFound)
         }
+    }
+
+    func testDeleteFailureCase() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+        
+        try app.test(.DELETE, "items", afterResponse: { res in
+            XCTAssertEqual(res.status, .notFound)
+        })
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -103,8 +103,8 @@ final class AppTests: XCTestCase {
             let postedItem = try res.content.decode(TestItem.self)
             let patchItem = EditedItem(title: "New title", body: nil, state: nil, deadline: nil)
             let patchBody = try jsonEncoder.encodeAsByteBuffer(patchItem, allocator: ByteBufferAllocator())
-            if let id = postItem.id {
-                try app.test(.PATCH, "item/id", headers: header, body: patchBody) { res in
+            if let id = postedItem.id {
+                try app.test(.PATCH, "item/\(id)", headers: header, body: patchBody) { res in
                     XCTAssertEqual(res.status, .ok)
                 }
             }
@@ -131,9 +131,8 @@ final class AppTests: XCTestCase {
         
         try app.test(.POST, "item", headers: header, body: postBody) { res in
             XCTAssertEqual(res.status, .created)
-            let postedItem = try res.content.decode(TestItem.self)
             if let id = postItem.id {
-                try app.test(.DELETE, "item/id?key=zziruru_taetae_cheer_up") { res in
+                try app.test(.DELETE, "item/\(id)?key=zziruru_taetae_cheer_up") { res in
                     XCTAssertEqual(res.status, .ok)
                 }
             }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -39,4 +39,48 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .created)
         }
     }
+
+    func testPostFailureCase_longTitle() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+
+        let longTitle = "title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. title이 500자 이상이면 post할 수 없습니다. "
+        let item = Item(title: longTitle, body: "body", state: .todo, deadline: nil)
+        let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
+        
+        try app.test(.POST, "item", headers: header, body: body) { res in
+            XCTAssertEqual(res.status, .badRequest)
+        }
+    }
+    
+    func testPostFailureCase_longBody() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+
+        let longBody = "Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다. Body가 1000자 이상이면 post할 수 없습니다."
+        let item = Item(title: "title", body: longBody, state: .todo, deadline: nil)
+        let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
+        
+        try app.test(.POST, "item", headers: header, body: body) { res in
+            XCTAssertEqual(res.status, .badRequest)
+        }
+    }
+
+    func testPatchSuccessCase() throws {
+        
+    }
+
+    func testPatchFailureCase() throws {
+        
+    }
+
+    func testDeleteSuccessCase() throws {
+        
+    }
+
+    func testDeleteFailureCase() throws {
+        
+    }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -68,19 +68,16 @@ final class AppTests: XCTestCase {
         }
     }
 
-    func testPatchSuccessCase() throws {
-        
-    }
-
     func testPatchFailureCase() throws {
-        
-    }
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
 
-    func testDeleteSuccessCase() throws {
-        
-    }
+        let item = Item(title: "New title", body: "New body", state: .doing, deadline: nil)
+        let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
 
-    func testDeleteFailureCase() throws {
-        
+        try app.test(.PATCH, "item", headers: header, body: body) { res in
+            XCTAssertEqual(res.status, .notFound)
+        }
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -15,4 +15,15 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         })
     }
+
+    func testGetFailureCase() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+
+        let invalidURI = "item"
+        try app.test(.GET, invalidURI, afterResponse: { res in
+            XCTAssertEqual(res.status, .notFound)
+        })
+    }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -2,14 +2,17 @@
 import XCTVapor
 
 final class AppTests: XCTestCase {
-    func testHelloWorld() throws {
+    
+    let jsonEncoder = JSONEncoder()
+    let header: HTTPHeaders = ["Content-Type": "application/json; charset=utf-8"]
+    
+    func testGetSuccessCase() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         try configure(app)
 
-        try app.test(.GET, "hello", afterResponse: { res in
+        try app.test(.GET, "items", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "Hello, world!")
         })
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -26,4 +26,17 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .notFound)
         })
     }
+
+    func testPostSuccessCase() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+
+        let item = Item(title: "title", body: "body", state: .todo, deadline: nil)
+        let body = try jsonEncoder.encodeAsByteBuffer(item, allocator: ByteBufferAllocator())
+        
+        try app.test(.POST, "item", headers: header, body: body) { res in
+            XCTAssertEqual(res.status, .created)
+        }
+    }
 }


### PR DESCRIPTION
## [step4 구현]

- [x] XCTVapor 모듈을 사용하여 테스트를 수행합니다

  - 테스트 요청을 보내고 응답을 확인합니다
  - Request body가 필요한 경우 테스트 케이스 내에서 인코딩하여 사용합니다

## [고민사항]

### 1. 실패하는 경우의 수가 너무 많은데.. 어디서부터 어디까지 테스트를 해야하는지 잘 모르겠습니다.🧐 

### 2. PATCH나 DELETE같은 경우에는 서버 데이터의 id를 알아야 사용할 수 있는데요.
```swift
 try app.test(.PATCH, "item/1", headers: header, body: editiedbody) { res in
            XCTAssertEqual(res.status, .ok)
 }
```
```swift
 try app.test(.DELETE, "item/1", headers: header, body: editiedbody) { res in
            XCTAssertEqual(res.status, .ok)
 }
```

` "item/1" ` 이렇게 접근을 하는 것은 옳지 않은 것 같았습니다. (1번 데이터 존재하지 않을 수 있기 때문에)
그래서 

```swift
let postItem = Item(title: "title", body: "body", state: .todo, deadline: nil)
let postBody = try jsonEncoder.encodeAsByteBuffer(postItem, allocator: ByteBufferAllocator())
        
try app.test(.POST, "item", headers: header, body: postBody) { res in
            XCTAssertEqual(res.status, .created)
            let postedItem = try res.content.decode(Item.self)
            let patchItem = EditedItem(title: "New title", body: nil, state: nil, deadline: nil)
            let patchBody = try jsonEncoder.encodeAsByteBuffer(patchItem, allocator: ByteBufferAllocator())
            
            try app.test(.PATCH, "item/\(String(describing: postedItem.id))", headers: header, body: patchBody) { res in
                         XCTAssertEqual(res.status, .ok)
            }
 }
```

위처럼 post를 시도하고, 거기서 나온 res에서 id값을 찾아 접근하려고 했는데요!

`failed - typeMismatch(Swift.Optional<Foundation.Date>, Swift.DecodingError.Context(codingPath: [ModelCodingKey(stringValue: "last_modified", intValue: nil)], debugDescription: "Could not decode property", underlyingError: Optional(Swift.DecodingError.typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [ModelCodingKey(stringValue: "last_modified", intValue: nil)], debugDescription: "Expected to decode String but found a number instead.", underlyingError: nil)))))`

그럼 이렇게 decode에서 문제가 발생하더라고요... 그래서..!

```swift
    struct TestItem: Content {
        var id: Int?
        var title: String
        var body: String
        var state: State
        var deadline: Double?
        var last_modified: Double?
    }
```

이렇게 test내부에 따로 decode를 위한 타입을 구현하게 되었습니다.
이전 Item은 last_modified가 Date타입이어서 발생한 문제같은데,
이런식으로 해결하는게 괜찮은건지 모르겠습니다!

그리고 위 처럼 한다고해도...
아래와 같은 오류가, delete에서는 발생하지 않고 patch에서는 발생하고 있습니다...

![스크린샷 2021-04-15 21 11 41](https://user-images.githubusercontent.com/49546979/114867070-4e586700-9e2f-11eb-80b3-f2900572e4d6.png)

`Assertion failed: PostgresConnection deinitialized before being closed.`와 관련하여 구글링을 해보았는데도... 어떻게 해야할지 모르겠습니다...🤯
